### PR TITLE
Decolorize log file output

### DIFF
--- a/internal/domain/core/service/project/decolorizer.go
+++ b/internal/domain/core/service/project/decolorizer.go
@@ -1,0 +1,23 @@
+package project
+
+import (
+	"io"
+	"regexp"
+)
+
+type decolorizer struct {
+	w io.Writer
+}
+
+func (d *decolorizer) Write(p []byte) (n int, err error) {
+	decolorized := rgxANSI.ReplaceAll(p, nil)
+	_, err = d.w.Write(decolorized)
+	if err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[a-zA-Z\\d]*)*)?\u0007)|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PRZcf-ntqry=><~]))"
+
+var rgxANSI = regexp.MustCompile(ansi)

--- a/internal/domain/core/service/project/runner.go
+++ b/internal/domain/core/service/project/runner.go
@@ -81,7 +81,7 @@ func (p *Project) prepareLogFiles(commandName string, runner *model.Runner, cmd 
 		}
 		closers = append(closers, stdErrFile)
 
-		cmd.Stderr = io.MultiWriter(os.Stderr, stdErrFile)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &decolorizer{stdErrFile})
 
 		stdOutFile, err2 := p.createLogFile(commandName+".stdout", runner.Log.Overwrite)
 		if err2 != nil {
@@ -89,7 +89,7 @@ func (p *Project) prepareLogFiles(commandName string, runner *model.Runner, cmd 
 		}
 		closers = append(closers, stdOutFile)
 
-		cmd.Stdout = io.MultiWriter(os.Stdout, stdOutFile)
+		cmd.Stdout = io.MultiWriter(os.Stdout, &decolorizer{stdOutFile})
 	} else {
 		logFile, err2 := p.createLogFile(commandName, runner.Log.Overwrite)
 		if err2 != nil {
@@ -97,8 +97,8 @@ func (p *Project) prepareLogFiles(commandName string, runner *model.Runner, cmd 
 		}
 		closers = append(closers, logFile)
 
-		cmd.Stderr = io.MultiWriter(os.Stderr, logFile)
-		cmd.Stdout = io.MultiWriter(os.Stdout, logFile)
+		cmd.Stderr = io.MultiWriter(os.Stderr, &decolorizer{logFile})
+		cmd.Stdout = io.MultiWriter(os.Stdout, &decolorizer{logFile})
 	}
 
 	return closers, nil


### PR DESCRIPTION
Before:
```
[90m12:55AM[0m [32mINF[0m [1mcmd/api/migrator.go:36[0m[36m >[0m [1mno migration needed[0m
[90m12:55AM[0m [32mINF[0m [1mcmd/api/server.go:97[0m[36m >[0m [1mapi starting[0m [36mport=[0m8080
```

After:
```

12:59AM INF cmd/api/migrator.go:36 > no migration needed
12:59AM INF cmd/api/server.go:97 > api starting port=8080
```